### PR TITLE
Upgrade to Node 24 and add min-release-age

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -30,10 +30,10 @@ jobs:
           token: ${{ secrets.PACKAGE_ADMIN_PAT }}
           fetch-depth: 0
 
-      - name: Setup Node 18.x
-        uses: actions/setup-node@v3
+      - name: Setup Node 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "24"
 
       - name: Ensure we have a new enough npm version for trusted publishing
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/Chia-Network/core-registry-logger.git"
   },
-  "bugs":{
+  "bugs": {
     "url": "https://github.com/Chia-Network/core-registry-logger/issues"
   },
   "dependencies": {
@@ -26,5 +26,8 @@
     "Michael.Taylor <mtaylor@michaeltaylor3d.com>",
     "Chris Marslender <chrismarslender@gmail.com>",
     "Zach Brown <zachary.g.brown@gmail.com>"
-  ]
+  ],
+  "engines": {
+    "node": ">=24.14.1"
+  }
 }


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary
- Upgrades Node.js requirement to 24.14.1+ (active LTS)
- Adds `min-release-age=1` to `.npmrc`, telling npm to only resolve package versions published more than 1 day ago
- Supply-chain-attack mitigation: malicious packages are typically flagged within hours, so a 1-day quarantine avoids installing freshly-published compromised versions
- Node 24 ships npm 11.10+, which is required for the `min-release-age` feature

## Test plan
- [ ] CI passes with Node 24
- [ ] `npm install` works correctly
- [ ] `npm ci` works correctly
- [ ] Application builds and runs successfully

Made with [Cursor](https://cursor.com)